### PR TITLE
[Bugfix] Bugfixed the generator

### DIFF
--- a/src/styles/autogenerated/nemotheme.cpp
+++ b/src/styles/autogenerated/nemotheme.cpp
@@ -193,7 +193,7 @@ static inline int jsonToInt(const QJsonValue &value,
             trueValue = defines.value(valueString);
         }
     }
-        
+    
     double doubleValue = trueValue.toDouble();
     return (int) doubleValue;
 }
@@ -280,26 +280,38 @@ void NemoTheme::loadFromFile(const QString &fileName)
     // Setting properties for font
     QJsonObject stylesButtonTextFont = stylesButtonText.value("font").toObject();
     if (stylesButtonTextFont.contains("pointSize")) {
-        m_button->text()->font()->setPointSize(jsonToInt(stylesButtonText.value("font"), defines));
+        m_button->text()->font()->setPointSize(jsonToInt(stylesButtonTextFont.value("pointSize"), defines));
+    } else {
+        m_button->text()->font()->setPointSizeDefault();
     }
     if (stylesButtonTextFont.contains("weight")) {
-        m_button->text()->font()->setWeight(jsonToInt(stylesButtonText.value("font"), defines));
+        m_button->text()->font()->setWeight(jsonToInt(stylesButtonTextFont.value("weight"), defines));
+    } else {
+        m_button->text()->font()->setWeightDefault();
     }
     // Setting properties for pressedGradient
     QJsonObject stylesButtonPressedGradient = stylesButton.value("pressedGradient").toObject();
     m_button->pressedGradient()->setCenterColor(jsonToColor(jsonValue(stylesButtonPressedGradient, "centerColor", "pressedGradient"), defines));
     m_button->pressedGradient()->setEdgeColor(jsonToColor(jsonValue(stylesButtonPressedGradient, "edgeColor", "pressedGradient"), defines));
     if (stylesButtonPressedGradient.contains("width")) {
-        m_button->pressedGradient()->setWidth(jsonToInt(stylesButton.value("pressedGradient"), defines));
+        m_button->pressedGradient()->setWidth(jsonToInt(stylesButtonPressedGradient.value("width"), defines));
+    } else {
+        m_button->pressedGradient()->setWidthDefault();
     }
     if (stylesButtonPressedGradient.contains("height")) {
-        m_button->pressedGradient()->setHeight(jsonToInt(stylesButton.value("pressedGradient"), defines));
+        m_button->pressedGradient()->setHeight(jsonToInt(stylesButtonPressedGradient.value("height"), defines));
+    } else {
+        m_button->pressedGradient()->setHeightDefault();
     }
     if (stylesButtonPressedGradient.contains("center")) {
-        m_button->pressedGradient()->setCenter(jsonToDouble(stylesButton.value("pressedGradient"), defines));
+        m_button->pressedGradient()->setCenter(jsonToDouble(stylesButtonPressedGradient.value("center"), defines));
+    } else {
+        m_button->pressedGradient()->setCenterDefault();
     }
     if (stylesButtonPressedGradient.contains("edge")) {
-        m_button->pressedGradient()->setEdge(jsonToDouble(stylesButton.value("pressedGradient"), defines));
+        m_button->pressedGradient()->setEdge(jsonToDouble(stylesButtonPressedGradient.value("edge"), defines));
+    } else {
+        m_button->pressedGradient()->setEdgeDefault();
     }
     // Setting properties for primaryButton
     QJsonObject stylesPrimaryButton = styles.value("primaryButton").toObject();
@@ -310,26 +322,38 @@ void NemoTheme::loadFromFile(const QString &fileName)
     // Setting properties for font
     QJsonObject stylesPrimaryButtonTextFont = stylesPrimaryButtonText.value("font").toObject();
     if (stylesPrimaryButtonTextFont.contains("pointSize")) {
-        m_primaryButton->text()->font()->setPointSize(jsonToInt(stylesPrimaryButtonText.value("font"), defines));
+        m_primaryButton->text()->font()->setPointSize(jsonToInt(stylesPrimaryButtonTextFont.value("pointSize"), defines));
+    } else {
+        m_primaryButton->text()->font()->setPointSizeDefault();
     }
     if (stylesPrimaryButtonTextFont.contains("weight")) {
-        m_primaryButton->text()->font()->setWeight(jsonToInt(stylesPrimaryButtonText.value("font"), defines));
+        m_primaryButton->text()->font()->setWeight(jsonToInt(stylesPrimaryButtonTextFont.value("weight"), defines));
+    } else {
+        m_primaryButton->text()->font()->setWeightDefault();
     }
     // Setting properties for pressedGradient
     QJsonObject stylesPrimaryButtonPressedGradient = stylesPrimaryButton.value("pressedGradient").toObject();
     m_primaryButton->pressedGradient()->setCenterColor(jsonToColor(jsonValue(stylesPrimaryButtonPressedGradient, "centerColor", "pressedGradient"), defines));
     m_primaryButton->pressedGradient()->setEdgeColor(jsonToColor(jsonValue(stylesPrimaryButtonPressedGradient, "edgeColor", "pressedGradient"), defines));
     if (stylesPrimaryButtonPressedGradient.contains("width")) {
-        m_primaryButton->pressedGradient()->setWidth(jsonToInt(stylesPrimaryButton.value("pressedGradient"), defines));
+        m_primaryButton->pressedGradient()->setWidth(jsonToInt(stylesPrimaryButtonPressedGradient.value("width"), defines));
+    } else {
+        m_primaryButton->pressedGradient()->setWidthDefault();
     }
     if (stylesPrimaryButtonPressedGradient.contains("height")) {
-        m_primaryButton->pressedGradient()->setHeight(jsonToInt(stylesPrimaryButton.value("pressedGradient"), defines));
+        m_primaryButton->pressedGradient()->setHeight(jsonToInt(stylesPrimaryButtonPressedGradient.value("height"), defines));
+    } else {
+        m_primaryButton->pressedGradient()->setHeightDefault();
     }
     if (stylesPrimaryButtonPressedGradient.contains("center")) {
-        m_primaryButton->pressedGradient()->setCenter(jsonToDouble(stylesPrimaryButton.value("pressedGradient"), defines));
+        m_primaryButton->pressedGradient()->setCenter(jsonToDouble(stylesPrimaryButtonPressedGradient.value("center"), defines));
+    } else {
+        m_primaryButton->pressedGradient()->setCenterDefault();
     }
     if (stylesPrimaryButtonPressedGradient.contains("edge")) {
-        m_primaryButton->pressedGradient()->setEdge(jsonToDouble(stylesPrimaryButton.value("pressedGradient"), defines));
+        m_primaryButton->pressedGradient()->setEdge(jsonToDouble(stylesPrimaryButtonPressedGradient.value("edge"), defines));
+    } else {
+        m_primaryButton->pressedGradient()->setEdgeDefault();
     }
     // Setting properties for groove
     QJsonObject stylesGroove = styles.value("groove").toObject();
@@ -340,7 +364,9 @@ void NemoTheme::loadFromFile(const QString &fileName)
     m_textField->setSelectedTextColor(jsonToColor(jsonValue(stylesTextField, "selectedTextColor", "textField"), defines));
     m_textField->setSelectionColor(jsonToColor(jsonValue(stylesTextField, "selectionColor", "textField"), defines));
     if (stylesTextField.contains("pointSize")) {
-        m_textField->setPointSize(jsonToInt(styles.value("textField"), defines));
+        m_textField->setPointSize(jsonToInt(stylesTextField.value("pointSize"), defines));
+    } else {
+        m_textField->setPointSizeDefault();
     }
     // Setting properties for toolBar
     QJsonObject stylesToolBar = styles.value("toolBar").toObject();
@@ -356,38 +382,56 @@ void NemoTheme::loadFromFile(const QString &fileName)
     m_page->dimmer()->setStartColor(jsonToColor(jsonValue(stylesPageDimmer, "startColor", "dimmer"), defines));
     m_page->dimmer()->setEndColor(jsonToColor(jsonValue(stylesPageDimmer, "endColor", "dimmer"), defines));
     if (stylesPageDimmer.contains("height")) {
-        m_page->dimmer()->setHeight(jsonToInt(stylesPage.value("dimmer"), defines));
+        m_page->dimmer()->setHeight(jsonToInt(stylesPageDimmer.value("height"), defines));
+    } else {
+        m_page->dimmer()->setHeightDefault();
     }
     if (stylesPageDimmer.contains("startPosition")) {
-        m_page->dimmer()->setStartPosition(jsonToDouble(stylesPage.value("dimmer"), defines));
+        m_page->dimmer()->setStartPosition(jsonToDouble(stylesPageDimmer.value("startPosition"), defines));
+    } else {
+        m_page->dimmer()->setStartPositionDefault();
     }
     if (stylesPageDimmer.contains("endPosition")) {
-        m_page->dimmer()->setEndPosition(jsonToDouble(stylesPage.value("dimmer"), defines));
+        m_page->dimmer()->setEndPosition(jsonToDouble(stylesPageDimmer.value("endPosition"), defines));
+    } else {
+        m_page->dimmer()->setEndPositionDefault();
     }
     // Setting properties for spinner
     QJsonObject stylesSpinner = styles.value("spinner").toObject();
     if (stylesSpinner.contains("radius")) {
-        m_spinner->setRadius(jsonToInt(styles.value("spinner"), defines));
+        m_spinner->setRadius(jsonToInt(stylesSpinner.value("radius"), defines));
+    } else {
+        m_spinner->setRadiusDefault();
     }
     m_spinner->setPrimaryColor(jsonToColor(jsonValue(stylesSpinner, "primaryColor", "spinner"), defines));
     m_spinner->setSecondaryColor(jsonToColor(jsonValue(stylesSpinner, "secondaryColor", "spinner"), defines));
     if (stylesSpinner.contains("horizontalSpacing")) {
-        m_spinner->setHorizontalSpacing(jsonToInt(styles.value("spinner"), defines));
+        m_spinner->setHorizontalSpacing(jsonToInt(stylesSpinner.value("horizontalSpacing"), defines));
+    } else {
+        m_spinner->setHorizontalSpacingDefault();
     }
     if (stylesSpinner.contains("verticalSpacing")) {
-        m_spinner->setVerticalSpacing(jsonToInt(styles.value("spinner"), defines));
+        m_spinner->setVerticalSpacing(jsonToInt(stylesSpinner.value("verticalSpacing"), defines));
+    } else {
+        m_spinner->setVerticalSpacingDefault();
     }
     if (stylesSpinner.contains("initialStateDuration")) {
-        m_spinner->setInitialStateDuration(jsonToInt(styles.value("spinner"), defines));
+        m_spinner->setInitialStateDuration(jsonToInt(stylesSpinner.value("initialStateDuration"), defines));
+    } else {
+        m_spinner->setInitialStateDurationDefault();
     }
     if (stylesSpinner.contains("transitionDuration")) {
-        m_spinner->setTransitionDuration(jsonToInt(styles.value("spinner"), defines));
+        m_spinner->setTransitionDuration(jsonToInt(stylesSpinner.value("transitionDuration"), defines));
+    } else {
+        m_spinner->setTransitionDurationDefault();
     }
     // Setting properties for label
     QJsonObject stylesLabel = styles.value("label").toObject();
     m_label->setColor(jsonToColor(jsonValue(stylesLabel, "color", "label"), defines));
     if (stylesLabel.contains("pointSize")) {
-        m_label->setPointSize(jsonToInt(styles.value("label"), defines));
+        m_label->setPointSize(jsonToInt(stylesLabel.value("pointSize"), defines));
+    } else {
+        m_label->setPointSizeDefault();
     }
     // Setting properties for checkbox
     QJsonObject stylesCheckbox = styles.value("checkbox").toObject();

--- a/src/styles/autogenerated/nemothemebuttonpressedgradient.cpp
+++ b/src/styles/autogenerated/nemothemebuttonpressedgradient.cpp
@@ -70,6 +70,14 @@ void NemoThemeButtonPressedGradient::setWidth(int width)
     }
 }
 
+void NemoThemeButtonPressedGradient::setWidthDefault()
+{
+    if (m_width != 240) {
+        m_width = 240;
+        emit widthChanged();
+    }
+}
+
 int NemoThemeButtonPressedGradient::height() const
 {
     return m_height;
@@ -79,6 +87,14 @@ void NemoThemeButtonPressedGradient::setHeight(int height)
 {
     if (m_height != height) {
         m_height = height;
+        emit heightChanged();
+    }
+}
+
+void NemoThemeButtonPressedGradient::setHeightDefault()
+{
+    if (m_height != 240) {
+        m_height = 240;
         emit heightChanged();
     }
 }
@@ -96,6 +112,14 @@ void NemoThemeButtonPressedGradient::setCenter(double center)
     }
 }
 
+void NemoThemeButtonPressedGradient::setCenterDefault()
+{
+    if (m_center != 0.29) {
+        m_center = 0.29;
+        emit centerChanged();
+    }
+}
+
 double NemoThemeButtonPressedGradient::edge() const
 {
     return m_edge;
@@ -105,6 +129,14 @@ void NemoThemeButtonPressedGradient::setEdge(double edge)
 {
     if (m_edge != edge) {
         m_edge = edge;
+        emit edgeChanged();
+    }
+}
+
+void NemoThemeButtonPressedGradient::setEdgeDefault()
+{
+    if (m_edge != 0.5) {
+        m_edge = 0.5;
         emit edgeChanged();
     }
 }

--- a/src/styles/autogenerated/nemothemebuttonpressedgradient.h
+++ b/src/styles/autogenerated/nemothemebuttonpressedgradient.h
@@ -43,12 +43,16 @@ public:
     void setEdgeColor(const QColor &edgeColor);
     int width() const;
     void setWidth(int width);
+    void setWidthDefault();
     int height() const;
     void setHeight(int height);
+    void setHeightDefault();
     double center() const;
     void setCenter(double center);
+    void setCenterDefault();
     double edge() const;
     void setEdge(double edge);
+    void setEdgeDefault();
 Q_SIGNALS:
     void centerColorChanged();
     void edgeColorChanged();

--- a/src/styles/autogenerated/nemothemefont.cpp
+++ b/src/styles/autogenerated/nemothemefont.cpp
@@ -42,6 +42,14 @@ void NemoThemeFont::setPointSize(int pointSize)
     }
 }
 
+void NemoThemeFont::setPointSizeDefault()
+{
+    if (m_pointSize != 24) {
+        m_pointSize = 24;
+        emit pointSizeChanged();
+    }
+}
+
 int NemoThemeFont::weight() const
 {
     return m_weight;
@@ -51,6 +59,14 @@ void NemoThemeFont::setWeight(int weight)
 {
     if (m_weight != weight) {
         m_weight = weight;
+        emit weightChanged();
+    }
+}
+
+void NemoThemeFont::setWeightDefault()
+{
+    if (m_weight != 25) {
+        m_weight = 25;
         emit weightChanged();
     }
 }

--- a/src/styles/autogenerated/nemothemefont.h
+++ b/src/styles/autogenerated/nemothemefont.h
@@ -34,8 +34,10 @@ public:
     explicit NemoThemeFont(QObject *parent = 0);
     int pointSize() const;
     void setPointSize(int pointSize);
+    void setPointSizeDefault();
     int weight() const;
     void setWeight(int weight);
+    void setWeightDefault();
 Q_SIGNALS:
     void pointSizeChanged();
     void weightChanged();

--- a/src/styles/autogenerated/nemothemelabel.cpp
+++ b/src/styles/autogenerated/nemothemelabel.cpp
@@ -53,3 +53,11 @@ void NemoThemeLabel::setPointSize(int pointSize)
         emit pointSizeChanged();
     }
 }
+
+void NemoThemeLabel::setPointSizeDefault()
+{
+    if (m_pointSize != 24) {
+        m_pointSize = 24;
+        emit pointSizeChanged();
+    }
+}

--- a/src/styles/autogenerated/nemothemelabel.h
+++ b/src/styles/autogenerated/nemothemelabel.h
@@ -37,6 +37,7 @@ public:
     void setColor(const QColor &color);
     int pointSize() const;
     void setPointSize(int pointSize);
+    void setPointSizeDefault();
 Q_SIGNALS:
     void colorChanged();
     void pointSizeChanged();

--- a/src/styles/autogenerated/nemothemepagedimmer.cpp
+++ b/src/styles/autogenerated/nemothemepagedimmer.cpp
@@ -69,6 +69,14 @@ void NemoThemePageDimmer::setHeight(int height)
     }
 }
 
+void NemoThemePageDimmer::setHeightDefault()
+{
+    if (m_height != 15) {
+        m_height = 15;
+        emit heightChanged();
+    }
+}
+
 double NemoThemePageDimmer::startPosition() const
 {
     return m_startPosition;
@@ -82,6 +90,14 @@ void NemoThemePageDimmer::setStartPosition(double startPosition)
     }
 }
 
+void NemoThemePageDimmer::setStartPositionDefault()
+{
+    if (m_startPosition != 0) {
+        m_startPosition = 0;
+        emit startPositionChanged();
+    }
+}
+
 double NemoThemePageDimmer::endPosition() const
 {
     return m_endPosition;
@@ -91,6 +107,14 @@ void NemoThemePageDimmer::setEndPosition(double endPosition)
 {
     if (m_endPosition != endPosition) {
         m_endPosition = endPosition;
+        emit endPositionChanged();
+    }
+}
+
+void NemoThemePageDimmer::setEndPositionDefault()
+{
+    if (m_endPosition != 1.0) {
+        m_endPosition = 1.0;
         emit endPositionChanged();
     }
 }

--- a/src/styles/autogenerated/nemothemepagedimmer.h
+++ b/src/styles/autogenerated/nemothemepagedimmer.h
@@ -42,10 +42,13 @@ public:
     void setEndColor(const QColor &endColor);
     int height() const;
     void setHeight(int height);
+    void setHeightDefault();
     double startPosition() const;
     void setStartPosition(double startPosition);
+    void setStartPositionDefault();
     double endPosition() const;
     void setEndPosition(double endPosition);
+    void setEndPositionDefault();
 Q_SIGNALS:
     void startColorChanged();
     void endColorChanged();

--- a/src/styles/autogenerated/nemothemespinner.cpp
+++ b/src/styles/autogenerated/nemothemespinner.cpp
@@ -45,6 +45,14 @@ void NemoThemeSpinner::setRadius(int radius)
     }
 }
 
+void NemoThemeSpinner::setRadiusDefault()
+{
+    if (m_radius != 32) {
+        m_radius = 32;
+        emit radiusChanged();
+    }
+}
+
 QColor NemoThemeSpinner::primaryColor() const
 {
     return m_primaryColor;
@@ -84,6 +92,14 @@ void NemoThemeSpinner::setHorizontalSpacing(int horizontalSpacing)
     }
 }
 
+void NemoThemeSpinner::setHorizontalSpacingDefault()
+{
+    if (m_horizontalSpacing != 15) {
+        m_horizontalSpacing = 15;
+        emit horizontalSpacingChanged();
+    }
+}
+
 int NemoThemeSpinner::verticalSpacing() const
 {
     return m_verticalSpacing;
@@ -93,6 +109,14 @@ void NemoThemeSpinner::setVerticalSpacing(int verticalSpacing)
 {
     if (m_verticalSpacing != verticalSpacing) {
         m_verticalSpacing = verticalSpacing;
+        emit verticalSpacingChanged();
+    }
+}
+
+void NemoThemeSpinner::setVerticalSpacingDefault()
+{
+    if (m_verticalSpacing != 15) {
+        m_verticalSpacing = 15;
         emit verticalSpacingChanged();
     }
 }
@@ -110,6 +134,14 @@ void NemoThemeSpinner::setInitialStateDuration(int initialStateDuration)
     }
 }
 
+void NemoThemeSpinner::setInitialStateDurationDefault()
+{
+    if (m_initialStateDuration != 1500) {
+        m_initialStateDuration = 1500;
+        emit initialStateDurationChanged();
+    }
+}
+
 int NemoThemeSpinner::transitionDuration() const
 {
     return m_transitionDuration;
@@ -119,6 +151,14 @@ void NemoThemeSpinner::setTransitionDuration(int transitionDuration)
 {
     if (m_transitionDuration != transitionDuration) {
         m_transitionDuration = transitionDuration;
+        emit transitionDurationChanged();
+    }
+}
+
+void NemoThemeSpinner::setTransitionDurationDefault()
+{
+    if (m_transitionDuration != 500) {
+        m_transitionDuration = 500;
         emit transitionDurationChanged();
     }
 }

--- a/src/styles/autogenerated/nemothemespinner.h
+++ b/src/styles/autogenerated/nemothemespinner.h
@@ -40,18 +40,23 @@ public:
     explicit NemoThemeSpinner(QObject *parent = 0);
     int radius() const;
     void setRadius(int radius);
+    void setRadiusDefault();
     QColor primaryColor() const;
     void setPrimaryColor(const QColor &primaryColor);
     QColor secondaryColor() const;
     void setSecondaryColor(const QColor &secondaryColor);
     int horizontalSpacing() const;
     void setHorizontalSpacing(int horizontalSpacing);
+    void setHorizontalSpacingDefault();
     int verticalSpacing() const;
     void setVerticalSpacing(int verticalSpacing);
+    void setVerticalSpacingDefault();
     int initialStateDuration() const;
     void setInitialStateDuration(int initialStateDuration);
+    void setInitialStateDurationDefault();
     int transitionDuration() const;
     void setTransitionDuration(int transitionDuration);
+    void setTransitionDurationDefault();
 Q_SIGNALS:
     void radiusChanged();
     void primaryColorChanged();

--- a/src/styles/autogenerated/nemothemetextfield.cpp
+++ b/src/styles/autogenerated/nemothemetextfield.cpp
@@ -66,3 +66,11 @@ void NemoThemeTextField::setPointSize(int pointSize)
         emit pointSizeChanged();
     }
 }
+
+void NemoThemeTextField::setPointSizeDefault()
+{
+    if (m_pointSize != 24) {
+        m_pointSize = 24;
+        emit pointSizeChanged();
+    }
+}

--- a/src/styles/autogenerated/nemothemetextfield.h
+++ b/src/styles/autogenerated/nemothemetextfield.h
@@ -40,6 +40,7 @@ public:
     void setSelectionColor(const QColor &selectionColor);
     int pointSize() const;
     void setPointSize(int pointSize);
+    void setPointSizeDefault();
 Q_SIGNALS:
     void selectedTextColorChanged();
     void selectionColorChanged();

--- a/src/styles/themes/ugly.json
+++ b/src/styles/themes/ugly.json
@@ -38,6 +38,9 @@
             "selectedTextColor": "#ffffff",
             "selectionColor": "#0091e5"
         },
+        "toolBar": {
+            "background": "#000000"
+        },
         "window": {
             "background": "#000000"
         },
@@ -47,6 +50,17 @@
                 "startColor": "black",
                 "endColor": "transparent"
             }
+        },
+        "spinner": {
+            "primaryColor": "accentColor",
+            "secondaryColor": "transparent"
+        },
+        "label": {
+            "color": "#ffffff"
+        },
+        "checkbox": {
+            "back1": "#0091e5",
+            "back2": "#313131"
         }
     }
 }


### PR DESCRIPTION
The class generator used to provide wrong values for
properties that have a default value. This bugfix
also includes the capability to restore a default
value when switching from a theme providing an
overridden value to a theme providing no value.
Before, since there were no value, the old value
from the old theme was kept.
